### PR TITLE
Fixing docs.rs URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/Keats/tera.svg)](https://travis-ci.org/Keats/tera)
 [![Build status](https://ci.appveyor.com/api/projects/status/omd2auu2e9qc8ukd?svg=true)](https://ci.appveyor.com/project/Keats/tera)
 [![Crates.io](https://img.shields.io/crates/v/tera.svg)](https://crates.io/crates/tera)
-[![Docs](https://docs.rs/tera/badge.svg)](https://docs.rs/tera)
+[![Docs](https://docs.rs/tera/badge.svg)](https://docs.rs/crate/tera/)
 
 Tera is a template engine inspired by [Jinja2](http://jinja.pocoo.org/) and the [Django template language](https://docs.djangoproject.com/en/1.9/topics/templates/).
 
@@ -17,7 +17,7 @@ Tera is a template engine inspired by [Jinja2](http://jinja.pocoo.org/) and the 
 ```
 
 ## Documentation
-API documentation is available on [docs.rs](https://docs.rs/tera).
+API documentation is available on [docs.rs](https://docs.rs/crate/tera/).
 
 Tera documentation is available on its [site](https://tera.netlify.com/docs/installation/).
 


### PR DESCRIPTION
The docs.rs path appears to be broken.  Updated the badge and Documentation references :)

OLD: https://docs.rs/tera	
NEW: https://docs.rs/crate/tera/